### PR TITLE
【Fixed】`rails g`コマンドの際にassetsファイル、helperが生成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,10 @@ module Achieve
     config.active_record.raise_in_transactional_callbacks = true
 
     config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
+    # `rails g`コマンドの際にデフォルトで helper と assets ファイルが生成されないように設定
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1 

- `rails g`実行時に`assets`と`helper`をデフォルトで生成しないよう`config/application.rb`に設定を記述